### PR TITLE
DLSN-542: Encrypt PAYE cache data with feature toggle

### DIFF
--- a/app/common/config/ATSModule.scala
+++ b/app/common/config/ATSModule.scala
@@ -20,6 +20,7 @@ import paye.connectors.{CachingNpsConnector, DefaultNpsConnector, NpsConnector}
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
 import sa.connectors.{CachingSelfAssessmentODSConnector, DefaultSelfAssessmentODSConnector, SelfAssessmentODSConnector}
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 class ATSModule extends Module {
 
@@ -29,7 +30,7 @@ class ATSModule extends Module {
       bind[SelfAssessmentODSConnector].qualifiedWith("default").to[DefaultSelfAssessmentODSConnector],
       bind[NpsConnector].to[CachingNpsConnector],
       bind[NpsConnector].qualifiedWith("default").to[DefaultNpsConnector],
+      bind[Encrypter with Decrypter].toProvider[CryptoProvider],
       bind[ApplicationStartUp].toSelf.eagerly()
     )
-
 }

--- a/app/common/config/ApplicationConfig.scala
+++ b/app/common/config/ApplicationConfig.scala
@@ -80,6 +80,9 @@ class ApplicationConfig @Inject() (servicesConfig: ServicesConfig, configuration
 
   private lazy val mongoTTL: Long = configuration.getOptional[Int]("mongodb.timeToLiveInMinutes").getOrElse(15).toLong
 
+  lazy val mongoEncryptionEnabled: Boolean =
+    configuration.getOptional[Boolean]("mongo.encryption.enabled").getOrElse(true)
+
   def calculateExpiryTime(): Instant = Timestamp.valueOf(LocalDateTime.now.plusMinutes(mongoTTL)).toInstant
 
   lazy val environment: String = servicesConfig.getConfString("tax-summaries-hod.env", "local")

--- a/app/common/config/CryptoProvider.scala
+++ b/app/common/config/CryptoProvider.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import play.api.Configuration
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter, SymmetricCryptoFactory}
+
+import javax.inject.{Inject, Provider, Singleton}
+
+@Singleton
+class CryptoProvider @Inject() (
+  configuration: Configuration,
+  fakeEncrypterDecrypter: FakeEncrypterDecrypter
+) extends Provider[Encrypter with Decrypter] {
+
+  override def get(): Encrypter with Decrypter = {
+    val mongoEncryptionEnabled =
+      configuration.getOptional[Boolean]("mongo.encryption.enabled").getOrElse(true)
+
+    if (mongoEncryptionEnabled) {
+      SymmetricCryptoFactory.aesCryptoFromConfig(
+        baseConfigKey = "mongo.encryption",
+        configuration.underlying
+      )
+    } else {
+      fakeEncrypterDecrypter
+    }
+  }
+}

--- a/app/common/config/FakeEncrypterDecrypter.scala
+++ b/app/common/config/FakeEncrypterDecrypter.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import com.google.inject.{Inject, Singleton}
+import uk.gov.hmrc.crypto.*
+
+@Singleton
+class FakeEncrypterDecrypter @Inject() () extends Encrypter with Decrypter {
+
+  override def encrypt(plain: PlainContent): Crypted =
+    plain match {
+      case PlainText(text)   => Crypted(text)
+      case PlainBytes(bytes) => Crypted(new String(bytes, "UTF-8"))
+    }
+
+  override def decrypt(reversiblyEncrypted: Crypted): PlainText =
+    PlainText(reversiblyEncrypted.value)
+
+  override def decryptAsBytes(reversiblyEncrypted: Crypted): PlainBytes =
+    PlainBytes(reversiblyEncrypted.value.getBytes("UTF-8"))
+}

--- a/app/paye/models/PayeAtsMiddleTierMongo.scala
+++ b/app/paye/models/PayeAtsMiddleTierMongo.scala
@@ -16,7 +16,9 @@
 
 package paye.models
 
-import play.api.libs.json.{Format, JsObject, Json}
+import paye.services.SensitiveFormatService.SensitiveJsObject
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Format, JsObject, JsPath, Json, OWrites, Reads}
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
@@ -29,6 +31,42 @@ case class PayeAtsMiddleTierMongo(
 
 object PayeAtsMiddleTierMongo extends MongoJavatimeFormats.Implicits {
 
-  implicit val format: Format[PayeAtsMiddleTierMongo] = Json.format[PayeAtsMiddleTierMongo]
+  implicit val format: Format[PayeAtsMiddleTierMongo] =
+    Json.format[PayeAtsMiddleTierMongo]
 
+  def formatSensitive(
+    formatSensitiveObject: Format[SensitiveJsObject]
+  ): Format[PayeAtsMiddleTierMongo] = {
+
+    val formatInstant: Format[Instant] =
+      MongoJavatimeFormats.instantFormat
+
+    val reads: Reads[PayeAtsMiddleTierMongo] =
+      (
+        (JsPath \ "_id").read[String] and
+          (JsPath \ "data").read[SensitiveJsObject](formatSensitiveObject) and
+          (JsPath \ "expiresAt").read[Instant](formatInstant)
+      ) { (id, sensitiveData, expiresAt) =>
+        PayeAtsMiddleTierMongo(
+          _id = id,
+          data = sensitiveData.decryptedValue,
+          expiresAt = expiresAt
+        )
+      }
+
+    val writes: OWrites[PayeAtsMiddleTierMongo] =
+      (
+        (JsPath \ "_id").write[String] and
+          (JsPath \ "data").write[SensitiveJsObject](formatSensitiveObject) and
+          (JsPath \ "expiresAt").write[Instant](formatInstant)
+      ) { mongo =>
+        (
+          mongo._id,
+          SensitiveJsObject(mongo.data),
+          mongo.expiresAt
+        )
+      }
+
+    Format(reads, writes)
+  }
 }

--- a/app/paye/repositories/NpsCacheRepository.scala
+++ b/app/paye/repositories/NpsCacheRepository.scala
@@ -20,6 +20,8 @@ import common.config.ApplicationConfig
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.*
 import paye.models.PayeAtsMiddleTierMongo
+import paye.services.SensitiveFormatService
+import paye.utils.HashUtil
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
@@ -29,12 +31,18 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class NpsCacheRepository @Inject() (config: ApplicationConfig, mongoComponent: MongoComponent)(implicit
+class NpsCacheRepository @Inject() (
+  config: ApplicationConfig,
+  mongoComponent: MongoComponent,
+  sensitiveFormatService: SensitiveFormatService
+)(implicit
   ec: ExecutionContext
 ) extends PlayMongoRepository[PayeAtsMiddleTierMongo](
       collectionName = "paye-cache",
       mongoComponent = mongoComponent,
-      domainFormat = PayeAtsMiddleTierMongo.format,
+      domainFormat = PayeAtsMiddleTierMongo.formatSensitive(
+        sensitiveFormatService.sensitiveFormatJsObject
+      ),
       indexes = Seq(
         IndexModel(
           Indexes.ascending("expiresAt"),
@@ -47,15 +55,22 @@ class NpsCacheRepository @Inject() (config: ApplicationConfig, mongoComponent: M
 
   private def filterById(id: String): Bson = Filters.equal("_id", id)
 
-  def get(nino: String, taxYear: Int): Future[Option[PayeAtsMiddleTierMongo]] = {
-    // id is s"$nino$taxYear"
-    val modifier = Updates.set("expiresAt", config.calculateExpiryTime())
-    collection.findOneAndUpdate(filterById(s"$nino$taxYear"), modifier).toFutureOption()
+  private def cacheId(nino: String, taxYear: Int): String =
+    HashUtil.sha256(
+      s"${nino.trim.toUpperCase}$taxYear"
+    )
 
+  def get(nino: String, taxYear: Int): Future[Option[PayeAtsMiddleTierMongo]] = {
+
+    val id       = cacheId(nino, taxYear)
+    val modifier = Updates.set("expiresAt", config.calculateExpiryTime())
+    collection.findOneAndUpdate(filterById(id), modifier).toFutureOption()
   }
 
   def set(nino: String, taxYear: Int, data: JsObject): Future[Boolean] = {
-    val mongoData = PayeAtsMiddleTierMongo(s"$nino$taxYear", data, config.calculateExpiryTime())
+
+    val id        = cacheId(nino, taxYear)
+    val mongoData = PayeAtsMiddleTierMongo(id, data, config.calculateExpiryTime())
     collection
       .replaceOne(
         filter = filterById(mongoData._id),

--- a/app/paye/services/SensitiveFormatService.scala
+++ b/app/paye/services/SensitiveFormatService.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paye.services
+
+import com.google.inject.Inject
+import play.api.libs.json.*
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, PlainText, Sensitive}
+import common.config.ApplicationConfig
+
+import scala.util.{Failure, Success, Try}
+
+class SensitiveFormatService @Inject() (encrypterDecrypter: Encrypter with Decrypter, config: ApplicationConfig) {
+  import SensitiveFormatService.*
+
+  private def writeJsObjectWithEncryption(jsObject: JsObject): JsValue =
+    if (config.mongoEncryptionEnabled) {
+      JsString(encrypterDecrypter.encrypt(PlainText(Json.stringify(jsObject))).value)
+    } else {
+      jsObject
+    }
+
+  private def sensitiveReadsJsObject: Reads[SensitiveJsObject] = {
+    case JsString(s)        =>
+      Try(encrypterDecrypter.decrypt(Crypted(s))) match {
+        case Success(plainText) =>
+          JsSuccess(SensitiveJsObject(Json.parse(plainText.value).as[JsObject]))
+
+        /*
+            Both of the below cases cater for two scenarios where the value is not encrypted:-
+              either an unencrypted JsString or any other JsValue.
+            This is to avoid breaking users' session in case data written before encryption introduced.
+         */
+
+        case Failure(_: SecurityException) => JsSuccess(SensitiveJsObject(JsString(s).as[JsObject]))
+        case Failure(exception)            => throw exception
+      }
+    case jsObject: JsObject => JsSuccess(SensitiveJsObject(jsObject))
+    case other              => JsError(s"Unexpected JsValue: $other")
+  }
+
+  def sensitiveFormatJsObject: Format[SensitiveJsObject] =
+    Format(
+      sensitiveReadsJsObject,
+      sensitiveJsObject => writeJsObjectWithEncryption(sensitiveJsObject.decryptedValue)
+    )
+}
+
+object SensitiveFormatService {
+  case class SensitiveJsObject(override val decryptedValue: JsObject) extends Sensitive[JsObject]
+}

--- a/app/paye/utils/HashUtil.scala
+++ b/app/paye/utils/HashUtil.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paye.utils
+
+import java.security.MessageDigest
+
+object HashUtil {
+
+  private val Algorithm = "SHA-256"
+
+  def sha256(value: String): String =
+    MessageDigest
+      .getInstance(Algorithm)
+      .digest(value.getBytes("UTF-8"))
+      .map("%02x".format(_))
+      .mkString
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,6 +44,8 @@ application.session.secure = false
 # ~~~~~
 play.i18n.langs = ["en"]
 
+mongo.encryption.enabled = true
+mongo.encryption.key = "someLocalEncryptionKey=="
 
 mongodb {
   uri = "mongodb://localhost/tax-summaries"

--- a/it/test/common/repositories/RepositorySpec.scala
+++ b/it/test/common/repositories/RepositorySpec.scala
@@ -19,6 +19,7 @@ package common.repositories
 import common.utils.IntegrationSpec
 import paye.models.{PayeAtsMiddleTier, PayeAtsMiddleTierMongo}
 import paye.repositories.NpsCacheRepository
+import paye.utils.HashUtil
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.test.PlayMongoRepositorySupport
@@ -56,6 +57,9 @@ class RepositorySpec extends IntegrationSpec with PlayMongoRepositorySupport[Pay
       val storedOk = serviceRepo.set("NINONINO", taxYear, dataObject)
       storedOk.futureValue mustBe true
 
+      val expectedId =
+        HashUtil.sha256(s"NINONINO$taxYear")
+
       val retrieved = serviceRepo
         .get("NINONINO", taxYear)
         .map(
@@ -63,7 +67,7 @@ class RepositorySpec extends IntegrationSpec with PlayMongoRepositorySupport[Pay
         )
         .futureValue
       val dataMongo = PayeAtsMiddleTierMongo(
-        _id = s"NINONINO$taxYear",
+        _id = expectedId,
         data = dataObject,
         expiresAt = Instant.now().plus(Duration.ofMinutes(minuteOffset)).truncatedTo(ChronoUnit.MINUTES)
       )

--- a/it/test/common/utils/IntegrationSpec.scala
+++ b/it/test/common/utils/IntegrationSpec.scala
@@ -20,6 +20,7 @@ import cats.data.EitherT
 import cats.instances.future.*
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import common.config.ATSModule
+import common.config.CryptoProvider
 import common.models.admin.SaDetailsFromHipToggle
 import org.apache.pekko.Done
 import org.mockito.Mockito.when
@@ -38,6 +39,7 @@ import uk.gov.hmrc.domain.{Nino, NinoGenerator, SaUtr, SaUtrGenerator}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongoFeatureToggles.model.FeatureFlag
 import uk.gov.hmrc.mongoFeatureToggles.services.FeatureFlagService
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -130,7 +132,8 @@ trait IntegrationSpec
         bind[NpsConnector].to[DefaultNpsConnector],
         bind[NpsConnector].qualifiedWith("default").to[DefaultNpsConnector],
         bind[AsyncCacheApi].toInstance(mockCacheApi),
-        bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[Encrypter with Decrypter].toProvider[CryptoProvider]
       )
       .configure(
         "microservice.services.tax-summaries-hod.port" -> server.port(),

--- a/test/common/config/CryptoProviderSpec.scala
+++ b/test/common/config/CryptoProviderSpec.scala
@@ -18,6 +18,7 @@ package common.config
 
 import common.utils.BaseSpec
 import play.api.Configuration
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 class CryptoProviderSpec extends BaseSpec {
 
@@ -31,6 +32,18 @@ class CryptoProviderSpec extends BaseSpec {
       val provider               = new CryptoProvider(configuration, fakeEncrypterDecrypter)
 
       provider.get() mustBe fakeEncrypterDecrypter
+    }
+
+    "return crypto when mongo encryption is enabled" in {
+      val configuration = Configuration(
+        "mongo.encryption.enabled" -> true,
+        "mongo.encryption.key" -> "12345678901234567890123456789012"
+      )
+
+      val fakeEncrypterDecrypter = new FakeEncrypterDecrypter()
+      val provider = new CryptoProvider(configuration, fakeEncrypterDecrypter)
+
+      provider.get() mustBe a[Encrypter with Decrypter]
     }
   }
 }

--- a/test/common/config/CryptoProviderSpec.scala
+++ b/test/common/config/CryptoProviderSpec.scala
@@ -37,11 +37,11 @@ class CryptoProviderSpec extends BaseSpec {
     "return crypto when mongo encryption is enabled" in {
       val configuration = Configuration(
         "mongo.encryption.enabled" -> true,
-        "mongo.encryption.key" -> "12345678901234567890123456789012"
+        "mongo.encryption.key"     -> "12345678901234567890123456789012"
       )
 
       val fakeEncrypterDecrypter = new FakeEncrypterDecrypter()
-      val provider = new CryptoProvider(configuration, fakeEncrypterDecrypter)
+      val provider               = new CryptoProvider(configuration, fakeEncrypterDecrypter)
 
       provider.get() mustBe a[Encrypter with Decrypter]
     }

--- a/test/common/config/CryptoProviderSpec.scala
+++ b/test/common/config/CryptoProviderSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import common.utils.BaseSpec
+import play.api.Configuration
+
+class CryptoProviderSpec extends BaseSpec {
+
+  "CryptoProvider" must {
+    "return FakeEncrypterDecrypter when mongo encryption is disabled" in {
+      val configuration = Configuration(
+        "mongo.encryption.enabled" -> false
+      )
+
+      val fakeEncrypterDecrypter = new FakeEncrypterDecrypter()
+      val provider               = new CryptoProvider(configuration, fakeEncrypterDecrypter)
+
+      provider.get() mustBe fakeEncrypterDecrypter
+    }
+  }
+}

--- a/test/common/config/FakeEncrypterDecrypterSpec.scala
+++ b/test/common/config/FakeEncrypterDecrypterSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import common.utils.BaseSpec
+import uk.gov.hmrc.crypto.{Crypted, PlainText}
+
+class FakeEncrypterDecrypterSpec extends BaseSpec {
+
+  private val fake = new FakeEncrypterDecrypter()
+
+  "FakeEncrypterDecrypter" must {
+    "return plain text as crypted text" in {
+      fake.encrypt(PlainText("abc")) mustBe Crypted("abc")
+    }
+
+    "decrypt crypted text as plain text" in {
+      fake.decrypt(Crypted("abc")) mustBe PlainText("abc")
+    }
+  }
+}

--- a/test/paye/services/SensitiveFormatServiceSpec.scala
+++ b/test/paye/services/SensitiveFormatServiceSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paye.services
+
+import common.config.ApplicationConfig
+import common.utils.BaseSpec
+import paye.services.SensitiveFormatService.SensitiveJsObject
+import org.mockito.Mockito.{reset, times, verify, when}
+import org.scalatest.BeforeAndAfterEach
+import org.mockito.ArgumentMatchers.any
+
+import play.api.libs.json.{JsObject, JsString, JsValue, Json}
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, PlainText}
+
+class SensitiveFormatServiceSpec extends BaseSpec with BeforeAndAfterEach {
+
+  private trait EncrypterDecrypter extends Encrypter with Decrypter
+
+  private implicit val mockEncrypterDecrypter: EncrypterDecrypter = mock[EncrypterDecrypter]
+  private val encryptedValueAsString: String                      = "encrypted"
+  private val encryptedValue: Crypted                             = Crypted(encryptedValueAsString)
+  private val unencryptedJsObject: JsObject                       = Json.obj(
+    "testa" -> "valuea",
+    "testb" -> "valueb"
+  )
+
+  private val sensitiveJsObject: SensitiveJsObject = SensitiveJsObject(unencryptedJsObject)
+  private val mockMongoConfig                      = mock[ApplicationConfig]
+  private val sensitiveFormatService               = new SensitiveFormatService(mockEncrypterDecrypter, mockMongoConfig)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockEncrypterDecrypter)
+    reset(mockMongoConfig)
+    when(mockMongoConfig.mongoEncryptionEnabled).thenReturn(true)
+    ()
+  }
+
+  "sensitiveFormatJsObject" must {
+    "write JsObject, calling encrypt when mongo encryption enabled" in {
+      when(mockEncrypterDecrypter.encrypt(any())).thenReturn(encryptedValue)
+
+      val result: JsValue = Json.toJson(sensitiveJsObject)(sensitiveFormatService.sensitiveFormatJsObject)
+
+      result mustBe JsString(encryptedValueAsString)
+
+      verify(mockEncrypterDecrypter, times(1)).encrypt(any())
+    }
+    "write JsObject, not calling encrypt when mongo encryption disabled" in {
+      when(mockEncrypterDecrypter.encrypt(any())).thenReturn(encryptedValue)
+      when(mockMongoConfig.mongoEncryptionEnabled).thenReturn(false)
+
+      val result: JsValue = Json.toJson(sensitiveJsObject)(sensitiveFormatService.sensitiveFormatJsObject)
+
+      result mustBe unencryptedJsObject
+
+      verify(mockEncrypterDecrypter, times(0)).encrypt(any())
+    }
+
+    "read unencrypted JsObject without calling decrypt" in {
+      when(mockEncrypterDecrypter.decrypt(any())).thenReturn(PlainText(Json.stringify(unencryptedJsObject)))
+      when(mockMongoConfig.mongoEncryptionEnabled).thenReturn(false)
+
+      val result =
+        unencryptedJsObject.as[SensitiveJsObject](sensitiveFormatService.sensitiveFormatJsObject)
+
+      result mustBe sensitiveJsObject
+
+      verify(mockEncrypterDecrypter, times(0)).decrypt(any())
+    }
+    "read encrypted JsString by calling decrypt" in {
+      when(mockEncrypterDecrypter.decrypt(any()))
+        .thenReturn(PlainText(Json.stringify(unencryptedJsObject)))
+
+      val result =
+        JsString(encryptedValueAsString).as[SensitiveJsObject](sensitiveFormatService.sensitiveFormatJsObject)
+
+      result mustBe sensitiveJsObject
+
+      verify(mockEncrypterDecrypter, times(1)).decrypt(any())
+    }
+  }
+}


### PR DESCRIPTION
Add encryption for `data` object in PAYE cache collection
Add Mongo encryption feature toggle in application.conf
Add hashed cache key for `_id` containing NINO + taxYear
