### PR TITLE
DLSN-542: Encrypt PAYE cache data with feature toggle

### DIFF
--- a/app/common/config/ATSModule.scala
+++ b/app/common/config/ATSModule.scala
@@ -20,6 +20,7 @@ import paye.connectors.{CachingNpsConnector, DefaultNpsConnector, NpsConnector}
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
 import sa.connectors.{CachingSelfAssessmentODSConnector, DefaultSelfAssessmentODSConnector, SelfAssessmentODSConnector}
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 class ATSModule extends Module {
 
@@ -29,7 +30,7 @@ class ATSModule extends Module {
       bind[SelfAssessmentODSConnector].qualifiedWith("default").to[DefaultSelfAssessmentODSConnector],
       bind[NpsConnector].to[CachingNpsConnector],
       bind[NpsConnector].qualifiedWith("default").to[DefaultNpsConnector],
+      bind[Encrypter with Decrypter].toProvider[CryptoProvider],
       bind[ApplicationStartUp].toSelf.eagerly()
     )
-
 }

--- a/app/common/config/ATSModule.scala
+++ b/app/common/config/ATSModule.scala
@@ -17,9 +17,9 @@
 package common.config
 
 import paye.connectors.{CachingNpsConnector, DefaultNpsConnector, NpsConnector}
+import sa.connectors.{CachingSelfAssessmentODSConnector, DefaultSelfAssessmentODSConnector, SelfAssessmentODSConnector}
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import sa.connectors.{CachingSelfAssessmentODSConnector, DefaultSelfAssessmentODSConnector, SelfAssessmentODSConnector}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 class ATSModule extends Module {

--- a/app/common/config/ApplicationConfig.scala
+++ b/app/common/config/ApplicationConfig.scala
@@ -80,6 +80,9 @@ class ApplicationConfig @Inject() (servicesConfig: ServicesConfig, configuration
 
   private lazy val mongoTTL: Long = configuration.getOptional[Int]("mongodb.timeToLiveInMinutes").getOrElse(15).toLong
 
+  lazy val mongoEncryptionEnabled: Boolean =
+    configuration.getOptional[Boolean]("mongo.encryption.enabled").getOrElse(true)
+
   def calculateExpiryTime(): Instant = Timestamp.valueOf(LocalDateTime.now.plusMinutes(mongoTTL)).toInstant
 
   lazy val environment: String = servicesConfig.getConfString("tax-summaries-hod.env", "local")

--- a/app/common/config/CryptoProvider.scala
+++ b/app/common/config/CryptoProvider.scala
@@ -23,21 +23,18 @@ import javax.inject.{Inject, Provider, Singleton}
 
 @Singleton
 class CryptoProvider @Inject() (
-  configuration: Configuration,
+  cryptoConfiguration: Configuration,
+  applicationConfig: ApplicationConfig,
   fakeEncrypterDecrypter: FakeEncrypterDecrypter
 ) extends Provider[Encrypter with Decrypter] {
 
-  override def get(): Encrypter with Decrypter = {
-    val mongoEncryptionEnabled =
-      configuration.getOptional[Boolean]("mongo.encryption.enabled").getOrElse(true)
-
-    if (mongoEncryptionEnabled) {
+  override def get(): Encrypter with Decrypter =
+    if (applicationConfig.mongoEncryptionEnabled) {
       SymmetricCryptoFactory.aesCryptoFromConfig(
         baseConfigKey = "mongo.encryption",
-        configuration.underlying
+        cryptoConfiguration.underlying
       )
     } else {
       fakeEncrypterDecrypter
     }
-  }
 }

--- a/app/common/config/CryptoProvider.scala
+++ b/app/common/config/CryptoProvider.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import play.api.Configuration
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter, SymmetricCryptoFactory}
+
+import javax.inject.{Inject, Provider, Singleton}
+
+@Singleton
+class CryptoProvider @Inject() (
+  configuration: Configuration,
+  fakeEncrypterDecrypter: FakeEncrypterDecrypter
+) extends Provider[Encrypter with Decrypter] {
+
+  override def get(): Encrypter with Decrypter = {
+    val mongoEncryptionEnabled =
+      configuration.getOptional[Boolean]("mongo.encryption.enabled").getOrElse(true)
+
+    if (mongoEncryptionEnabled) {
+      SymmetricCryptoFactory.aesCryptoFromConfig(
+        baseConfigKey = "mongo.encryption",
+        configuration.underlying
+      )
+    } else {
+      fakeEncrypterDecrypter
+    }
+  }
+}

--- a/app/common/config/FakeEncrypterDecrypter.scala
+++ b/app/common/config/FakeEncrypterDecrypter.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import com.google.inject.{Inject, Singleton}
+import uk.gov.hmrc.crypto.*
+
+@Singleton
+class FakeEncrypterDecrypter @Inject() () extends Encrypter with Decrypter {
+
+  override def encrypt(plain: PlainContent): Crypted =
+    plain match {
+      case PlainText(text)   => Crypted(text)
+      case PlainBytes(bytes) => Crypted(new String(bytes, "UTF-8"))
+    }
+
+  override def decrypt(reversiblyEncrypted: Crypted): PlainText =
+    PlainText(reversiblyEncrypted.value)
+
+  override def decryptAsBytes(reversiblyEncrypted: Crypted): PlainBytes =
+    PlainBytes(reversiblyEncrypted.value.getBytes("UTF-8"))
+}

--- a/app/paye/models/PayeAtsMiddleTierMongo.scala
+++ b/app/paye/models/PayeAtsMiddleTierMongo.scala
@@ -16,7 +16,9 @@
 
 package paye.models
 
-import play.api.libs.json.{Format, JsObject, Json}
+import paye.services.SensitiveFormatService.SensitiveJsObject
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Format, JsObject, JsPath, Json, OWrites, Reads}
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
@@ -29,6 +31,42 @@ case class PayeAtsMiddleTierMongo(
 
 object PayeAtsMiddleTierMongo extends MongoJavatimeFormats.Implicits {
 
-  implicit val format: Format[PayeAtsMiddleTierMongo] = Json.format[PayeAtsMiddleTierMongo]
+  implicit val format: Format[PayeAtsMiddleTierMongo] =
+    Json.format[PayeAtsMiddleTierMongo]
 
+  def formatSensitive(
+    formatSensitiveObject: Format[SensitiveJsObject]
+  ): Format[PayeAtsMiddleTierMongo] = {
+
+    val formatInstant: Format[Instant] =
+      MongoJavatimeFormats.instantFormat
+
+    val reads: Reads[PayeAtsMiddleTierMongo] =
+      (
+        (JsPath \ "_id").read[String] and
+          (JsPath \ "data").read[SensitiveJsObject](formatSensitiveObject) and
+          (JsPath \ "expiresAt").read[Instant](formatInstant)
+      ) { (id, sensitiveData, expiresAt) =>
+        PayeAtsMiddleTierMongo(
+          _id = id,
+          data = sensitiveData.decryptedValue,
+          expiresAt = expiresAt
+        )
+      }
+
+    val writes: OWrites[PayeAtsMiddleTierMongo] =
+      (
+        (JsPath \ "_id").write[String] and
+          (JsPath \ "data").write[SensitiveJsObject](formatSensitiveObject) and
+          (JsPath \ "expiresAt").write[Instant](formatInstant)
+      ) { mongo =>
+        (
+          mongo._id,
+          SensitiveJsObject(mongo.data),
+          mongo.expiresAt
+        )
+      }
+
+    Format(reads, writes)
+  }
 }

--- a/app/paye/repositories/NpsCacheRepository.scala
+++ b/app/paye/repositories/NpsCacheRepository.scala
@@ -17,11 +17,11 @@
 package paye.repositories
 
 import common.config.ApplicationConfig
-import org.mongodb.scala.bson.conversions.Bson
-import org.mongodb.scala.model.*
 import paye.models.PayeAtsMiddleTierMongo
 import paye.services.SensitiveFormatService
 import paye.utils.HashUtil
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.*
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
@@ -57,7 +57,7 @@ class NpsCacheRepository @Inject() (
 
   private def cacheId(nino: String, taxYear: Int): String =
     HashUtil.sha256(
-      s"${nino.trim.toUpperCase}$taxYear"
+      s"$nino$taxYear"
     )
 
   def get(nino: String, taxYear: Int): Future[Option[PayeAtsMiddleTierMongo]] = {

--- a/app/paye/repositories/NpsCacheRepository.scala
+++ b/app/paye/repositories/NpsCacheRepository.scala
@@ -20,6 +20,8 @@ import common.config.ApplicationConfig
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.*
 import paye.models.PayeAtsMiddleTierMongo
+import paye.services.SensitiveFormatService
+import paye.utils.HashUtil
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
@@ -29,12 +31,18 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class NpsCacheRepository @Inject() (config: ApplicationConfig, mongoComponent: MongoComponent)(implicit
+class NpsCacheRepository @Inject() (
+  config: ApplicationConfig,
+  mongoComponent: MongoComponent,
+  sensitiveFormatService: SensitiveFormatService
+)(implicit
   ec: ExecutionContext
 ) extends PlayMongoRepository[PayeAtsMiddleTierMongo](
       collectionName = "paye-cache",
       mongoComponent = mongoComponent,
-      domainFormat = PayeAtsMiddleTierMongo.format,
+      domainFormat = PayeAtsMiddleTierMongo.formatSensitive(
+        sensitiveFormatService.sensitiveFormatJsObject
+      ),
       indexes = Seq(
         IndexModel(
           Indexes.ascending("expiresAt"),
@@ -47,15 +55,22 @@ class NpsCacheRepository @Inject() (config: ApplicationConfig, mongoComponent: M
 
   private def filterById(id: String): Bson = Filters.equal("_id", id)
 
-  def get(nino: String, taxYear: Int): Future[Option[PayeAtsMiddleTierMongo]] = {
-    // id is s"$nino$taxYear"
-    val modifier = Updates.set("expiresAt", config.calculateExpiryTime())
-    collection.findOneAndUpdate(filterById(s"$nino$taxYear"), modifier).toFutureOption()
+  private def cacheId(nino: String, taxYear: Int): String =
+    HashUtil.sha256(
+      s"${nino.trim.toUpperCase}$taxYear"
+    )
 
+  def get(nino: String, taxYear: Int): Future[Option[PayeAtsMiddleTierMongo]] = {
+
+    val id       = cacheId(nino, taxYear)
+    val modifier = Updates.set("expiresAt", config.calculateExpiryTime())
+    collection.findOneAndUpdate(filterById(id), modifier).toFutureOption()
   }
 
   def set(nino: String, taxYear: Int, data: JsObject): Future[Boolean] = {
-    val mongoData = PayeAtsMiddleTierMongo(s"$nino$taxYear", data, config.calculateExpiryTime())
+
+    val id        = cacheId(nino, taxYear)
+    val mongoData = PayeAtsMiddleTierMongo(id, data, config.calculateExpiryTime())
     collection
       .replaceOne(
         filter = filterById(mongoData._id),

--- a/app/paye/services/SensitiveFormatService.scala
+++ b/app/paye/services/SensitiveFormatService.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paye.services
+
+import com.google.inject.Inject
+import play.api.libs.json.*
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, PlainText, Sensitive}
+import common.config.ApplicationConfig
+
+import scala.util.{Failure, Success, Try}
+
+class SensitiveFormatService @Inject() (encrypterDecrypter: Encrypter with Decrypter, config: ApplicationConfig) {
+  import SensitiveFormatService.*
+
+  private def writeJsObjectWithEncryption(jsObject: JsObject): JsValue =
+    if (config.mongoEncryptionEnabled) {
+      JsString(encrypterDecrypter.encrypt(PlainText(Json.stringify(jsObject))).value)
+    } else {
+      jsObject
+    }
+
+  private def sensitiveReadsJsObject: Reads[SensitiveJsObject] = {
+    case JsString(s)        =>
+      Try(encrypterDecrypter.decrypt(Crypted(s))) match {
+        case Success(plainText) =>
+          JsSuccess(SensitiveJsObject(Json.parse(plainText.value).as[JsObject]))
+
+        /*
+            Both of the below cases cater for two scenarios where the value is not encrypted:-
+              either an unencrypted JsString or any other JsValue.
+            This is to avoid breaking users' session in case data written before encryption introduced.
+         */
+
+        case Failure(_: SecurityException) => JsSuccess(SensitiveJsObject(JsString(s).as[JsObject]))
+        case Failure(exception)            => throw exception
+      }
+    case jsObject: JsObject => JsSuccess(SensitiveJsObject(jsObject))
+    case other              => JsError(s"Unexpected JsValue: $other")
+  }
+
+  def sensitiveFormatJsObject: Format[SensitiveJsObject] =
+    Format(
+      sensitiveReadsJsObject,
+      sensitiveJsObject => writeJsObjectWithEncryption(sensitiveJsObject.decryptedValue)
+    )
+}
+
+object SensitiveFormatService {
+  case class SensitiveJsObject(override val decryptedValue: JsObject) extends Sensitive[JsObject]
+}

--- a/app/paye/services/SensitiveFormatService.scala
+++ b/app/paye/services/SensitiveFormatService.scala
@@ -17,9 +17,9 @@
 package paye.services
 
 import com.google.inject.Inject
+import common.config.ApplicationConfig
 import play.api.libs.json.*
 import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, PlainText, Sensitive}
-import common.config.ApplicationConfig
 
 import scala.util.{Failure, Success, Try}
 

--- a/app/paye/utils/HashUtil.scala
+++ b/app/paye/utils/HashUtil.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paye.utils
+
+import java.security.MessageDigest
+
+object HashUtil {
+
+  private val Algorithm = "SHA-256"
+
+  def sha256(value: String): String =
+    MessageDigest
+      .getInstance(Algorithm)
+      .digest(value.getBytes("UTF-8"))
+      .map("%02x".format(_))
+      .mkString
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,6 +44,8 @@ application.session.secure = false
 # ~~~~~
 play.i18n.langs = ["en"]
 
+mongo.encryption.enabled = true
+mongo.encryption.key = "someLocalEncryptionKey=="
 
 mongodb {
   uri = "mongodb://localhost/tax-summaries"

--- a/it/test/common/repositories/RepositorySpec.scala
+++ b/it/test/common/repositories/RepositorySpec.scala
@@ -19,6 +19,7 @@ package common.repositories
 import common.utils.IntegrationSpec
 import paye.models.{PayeAtsMiddleTier, PayeAtsMiddleTierMongo}
 import paye.repositories.NpsCacheRepository
+import paye.utils.HashUtil
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.test.PlayMongoRepositorySupport
@@ -63,7 +64,7 @@ class RepositorySpec extends IntegrationSpec with PlayMongoRepositorySupport[Pay
         )
         .futureValue
       val dataMongo = PayeAtsMiddleTierMongo(
-        _id = s"NINONINO$taxYear",
+        _id = HashUtil.sha256(s"NINONINO$taxYear"),
         data = dataObject,
         expiresAt = Instant.now().plus(Duration.ofMinutes(minuteOffset)).truncatedTo(ChronoUnit.MINUTES)
       )

--- a/it/test/common/utils/IntegrationSpec.scala
+++ b/it/test/common/utils/IntegrationSpec.scala
@@ -21,6 +21,8 @@ import cats.instances.future.*
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import common.config.{ATSModule, CryptoProvider}
 import common.models.admin.SaDetailsFromHipToggle
+import sa.connectors.{DefaultSelfAssessmentODSConnector, SelfAssessmentODSConnector}
+import paye.connectors.{DefaultNpsConnector, NpsConnector}
 import org.apache.pekko.Done
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -28,12 +30,10 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import paye.connectors.{DefaultNpsConnector, NpsConnector}
 import play.api.Application
 import play.api.cache.AsyncCacheApi
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import sa.connectors.{DefaultSelfAssessmentODSConnector, SelfAssessmentODSConnector}
 import uk.gov.hmrc.domain.{Nino, NinoGenerator, SaUtr, SaUtrGenerator}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongoFeatureToggles.model.FeatureFlag

--- a/it/test/common/utils/IntegrationSpec.scala
+++ b/it/test/common/utils/IntegrationSpec.scala
@@ -19,7 +19,7 @@ package common.utils
 import cats.data.EitherT
 import cats.instances.future.*
 import com.github.tomakehurst.wiremock.client.WireMock.*
-import common.config.ATSModule
+import common.config.{ATSModule, CryptoProvider}
 import common.models.admin.SaDetailsFromHipToggle
 import org.apache.pekko.Done
 import org.mockito.Mockito.when
@@ -38,6 +38,7 @@ import uk.gov.hmrc.domain.{Nino, NinoGenerator, SaUtr, SaUtrGenerator}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongoFeatureToggles.model.FeatureFlag
 import uk.gov.hmrc.mongoFeatureToggles.services.FeatureFlagService
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
@@ -130,7 +131,8 @@ trait IntegrationSpec
         bind[NpsConnector].to[DefaultNpsConnector],
         bind[NpsConnector].qualifiedWith("default").to[DefaultNpsConnector],
         bind[AsyncCacheApi].toInstance(mockCacheApi),
-        bind[FeatureFlagService].toInstance(mockFeatureFlagService)
+        bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+        bind[Encrypter with Decrypter].toProvider[CryptoProvider]
       )
       .configure(
         "microservice.services.tax-summaries-hod.port" -> server.port(),

--- a/test/common/config/FakeEncrypterDecrypterSpec.scala
+++ b/test/common/config/FakeEncrypterDecrypterSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common.config
+
+import common.utils.BaseSpec
+import uk.gov.hmrc.crypto.{Crypted, PlainText}
+
+class FakeEncrypterDecrypterSpec extends BaseSpec {
+
+  private val crypto = new FakeEncrypterDecrypter()
+
+  "FakeEncrypterDecrypter" must {
+
+    "encrypt plain text into a Crypted value" in {
+      val text = PlainText("hello")
+
+      val result = crypto.encrypt(text)
+
+      result mustBe Crypted("hello")
+    }
+
+    "decrypt crypted text into a PlainText value" in {
+      val encrypted = Crypted("hello")
+
+      val result = crypto.decrypt(encrypted)
+
+      result mustBe PlainText("hello")
+    }
+  }
+}

--- a/test/paye/models/PayeAtsMiddleTierTest.scala
+++ b/test/paye/models/PayeAtsMiddleTierTest.scala
@@ -20,13 +20,25 @@ import common.utils.{BaseSpec, Generators}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.libs.json.{JsObject, Json}
 
+import java.time.Instant
+
 class PayeAtsMiddleTierTest extends BaseSpec with ScalaCheckPropertyChecks {
 
+  "format" must {
+    "write and read PayeAtsMiddleTierMongo" in {
+      val model = PayeAtsMiddleTierMongo(
+        _id = "id",
+        data = Json.obj("test" -> "value"),
+        expiresAt = Instant.ofEpochMilli(0)
+      )
+
+      Json.toJson(model).as[PayeAtsMiddleTierMongo] mustBe model
+    }
+  }
   "PayeAtsMiddleTier must round trip through Json " in {
     forAll(Generators.genPayeAsMiddleTier) { data =>
       val json = Json.toJson(data)
       val obj  = json.as[PayeAtsMiddleTier]
-
       obj mustBe data
     }
   }
@@ -36,6 +48,5 @@ class PayeAtsMiddleTierTest extends BaseSpec with ScalaCheckPropertyChecks {
     val json = Json.toJson(data).as[JsObject] - "includeBRDMessage"
     val obj  = json.as[PayeAtsMiddleTier]
     obj mustBe data
-
   }
 }

--- a/test/paye/services/SensitiveFormatServiceSpec.scala
+++ b/test/paye/services/SensitiveFormatServiceSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package paye.services
+
+import common.config.{ApplicationConfig, FakeEncrypterDecrypter}
+import common.utils.BaseSpec
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+import paye.services.SensitiveFormatService.SensitiveJsObject
+import play.api.libs.json.{JsObject, JsString, JsValue, Json}
+
+class SensitiveFormatServiceSpec extends BaseSpec with BeforeAndAfterEach {
+
+  private val crypto = new FakeEncrypterDecrypter()
+  private val config = mock[ApplicationConfig]
+
+  private val service = new SensitiveFormatService(crypto, config)
+
+  private val json: JsObject = Json.obj("nino" -> "MW609922A")
+  private val sensitiveJson  = SensitiveJsObject(json)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(config)
+  }
+
+  "SensitiveFormatService" must {
+    "write encrypted JsString when encryption is enabled" in {
+      when(config.mongoEncryptionEnabled).thenReturn(true)
+
+      val result: JsValue =
+        Json.toJson(sensitiveJson)(service.sensitiveFormatJsObject)
+      result mustBe JsString(Json.stringify(json))
+    }
+
+    "read encrypted JsString by decrypting it" in {
+      val result =
+        JsString(Json.stringify(json))
+          .as[SensitiveJsObject](service.sensitiveFormatJsObject)
+
+      result mustBe sensitiveJson
+    }
+  }
+}

--- a/test/paye/services/SensitiveFormatServiceSpec.scala
+++ b/test/paye/services/SensitiveFormatServiceSpec.scala
@@ -18,9 +18,9 @@ package paye.services
 
 import common.config.{ApplicationConfig, FakeEncrypterDecrypter}
 import common.utils.BaseSpec
+import paye.services.SensitiveFormatService.SensitiveJsObject
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.BeforeAndAfterEach
-import paye.services.SensitiveFormatService.SensitiveJsObject
 import play.api.libs.json.{JsObject, JsString, JsValue, Json}
 
 class SensitiveFormatServiceSpec extends BaseSpec with BeforeAndAfterEach {


### PR DESCRIPTION
Add encryption for data object in PAYE cache collection
Add Mongo encryption feature toggle in application.conf
Add hashed cache key for _id (nino+taxYear)